### PR TITLE
Add support for privileged and unprivileged connections

### DIFF
--- a/Source/MOLXPCConnection/MOLXPCConnection.h
+++ b/Source/MOLXPCConnection/MOLXPCConnection.h
@@ -22,7 +22,9 @@
 
  @code
  MOLXPCConnection *conn = [[MOLXPCConnection alloc] initServerWithName:@"MyServer"];
- conn.exportedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(MyServerProtocol)];
+ conn.privilegedExportedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(MyPriamryServerProtocol)];
+ conn.unprivilegedExportedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(MySecondaryServerProtocol)];
+ [conn allowUnprivilegedClients:YES];
  conn.exportedObject = myObject;
  [conn resume];
  @endcode
@@ -95,6 +97,11 @@
 - (void)resume;
 
 /**
+  Enables or disables the connection from unprivileged users. (server)
+*/
+- (void)allowUnprivilegedClients:(BOOL)enable;
+
+/**
  Invalidate the connection(s). This must be done before the object can be released.
  */
 - (void)invalidate;
@@ -113,9 +120,14 @@
 @property(readonly, nonatomic, nullable) id remoteObjectProxy;
 
 /**
- The interface this object exports. (server)
+ The privileged interface this object exports. (server)
  */
-@property(retain, nullable) NSXPCInterface *exportedInterface;
+@property(retain, nullable) NSXPCInterface *privilegedExportedInterface;
+
+/**
+ The unprivileged interface this object exports. (server)
+ */
+@property(retain, nullable) NSXPCInterface *unprivilegedExportedInterface;
 
 /**
  The object that responds to messages from the other end. (server)

--- a/Source/MOLXPCConnection/MOLXPCConnection.h
+++ b/Source/MOLXPCConnection/MOLXPCConnection.h
@@ -24,7 +24,6 @@
  MOLXPCConnection *conn = [[MOLXPCConnection alloc] initServerWithName:@"MyServer"];
  conn.privilegedExportedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(MyPriamryServerProtocol)];
  conn.unprivilegedExportedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(MySecondaryServerProtocol)];
- [conn allowUnprivilegedClients:YES];
  conn.exportedObject = myObject;
  [conn resume];
  @endcode
@@ -97,11 +96,6 @@
 - (void)resume;
 
 /**
-  Enables or disables the connection from unprivileged users. (server)
-*/
-- (void)allowUnprivilegedClients:(BOOL)enable;
-
-/**
  Invalidate the connection(s). This must be done before the object can be released.
  */
 - (void)invalidate;
@@ -122,12 +116,18 @@
 /**
  The privileged interface this object exports. (server)
  */
-@property(retain, nullable) NSXPCInterface *privilegedExportedInterface;
+@property(retain, nullable) NSXPCInterface *privilegedInterface;
 
 /**
  The unprivileged interface this object exports. (server)
  */
-@property(retain, nullable) NSXPCInterface *unprivilegedExportedInterface;
+@property(retain, nullable) NSXPCInterface *unprivilegedInterface;
+
+/**
+  Old interface property, please update to use privilegedExportedInterface and/or unprivilegedExportedInterface instead.
+*/
+@property(retain, nullable) NSXPCInterface *exportedInterface __attribute__((
+   deprecated("Use privilegedExportedInterface and / or unprivilegedExportedInterface instead.")));
 
 /**
  The object that responds to messages from the other end. (server)

--- a/Tests/MOLXPCConnectionTests.m
+++ b/Tests/MOLXPCConnectionTests.m
@@ -22,6 +22,9 @@
 @interface MOLXPCConnectionTest : XCTestCase
 @end
 
+@protocol DummyXPCProtocol
+@end
+
 @implementation MOLXPCConnectionTest
 
 - (void)testPlainInit {
@@ -67,6 +70,7 @@
   NSXPCListener *listener = [NSXPCListener anonymousListener];
 
   MOLXPCConnection *sutServer = [[MOLXPCConnection alloc] initServerWithListener:listener];
+  sutServer.unprivilegedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(DummyXPCProtocol)];
   [sutServer resume];
 
   __block XCTestExpectation *exp1 = [self expectationWithDescription:@"Client Invalidated"];
@@ -87,6 +91,7 @@
 
   XCTestExpectation *exp1 = [self expectationWithDescription:@"Server Accepted"];
   MOLXPCConnection *sutServer = [[MOLXPCConnection alloc] initServerWithListener:listener];
+  sutServer.unprivilegedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(DummyXPCProtocol)];
   sutServer.acceptedHandler = ^{
     [exp1 fulfill];
   };
@@ -105,6 +110,7 @@
 - (void)testConnectionInterruption {
   NSXPCListener *listener = [NSXPCListener anonymousListener];
   MOLXPCConnection *sutServer = [[MOLXPCConnection alloc] initServerWithListener:listener];
+  sutServer.unprivilegedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(DummyXPCProtocol)];
   [sutServer resume];
 
   __block XCTestExpectation *exp1 = [self expectationWithDescription:@"Client Invalidated"];


### PR DESCRIPTION
This PR adds support for separating the interface into privileged and unprivileged, depending on the permissions of the connecting client