### PR TITLE
expose synchronousRemoteObjectProxy

### DIFF
--- a/MOLXPCConnection.podspec
+++ b/MOLXPCConnection.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'MOLXPCConnection'
-  s.version      = '1.2'
-  s.platform     = :osx, '10.8'
+  s.version      = '1.3'
+  s.platform     = :osx, '10.11'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
   s.homepage     = 'https://github.com/google/macops-molxpcconnection'
   s.authors      = { 'Google Macops' => 'macops-external@google.com' }

--- a/MOLXPCConnection.xcodeproj/project.pbxproj
+++ b/MOLXPCConnection.xcodeproj/project.pbxproj
@@ -149,7 +149,6 @@
 				C75BA7DE1F66E6CE00E67A35 /* Sources */,
 				C75BA7DF1F66E6CE00E67A35 /* Frameworks */,
 				C75BA7E01F66E6CE00E67A35 /* Headers */,
-				21D8B3413270C4A3FB754B48 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -168,8 +167,6 @@
 				C75BA7EE1F66E79300E67A35 /* Sources */,
 				C75BA7EF1F66E79300E67A35 /* Frameworks */,
 				C75BA7F01F66E79300E67A35 /* Resources */,
-				654C6E1213F21D910C734CE2 /* [CP] Embed Pods Frameworks */,
-				8914C957262C878BF8285C3E /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -228,21 +225,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		21D8B3413270C4A3FB754B48 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MOLXPCConnection/Pods-MOLXPCConnection-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		3B5B88967B501B7F6BF5D494 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -277,36 +259,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		654C6E1213F21D910C734CE2 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MOLXPCConnectionTests/Pods-MOLXPCConnectionTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8914C957262C878BF8285C3E /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MOLXPCConnectionTests/Pods-MOLXPCConnectionTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -8,6 +8,12 @@ DEPENDENCIES:
   - MOLCodesignChecker
   - OCMock
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - MOLCertificate
+    - MOLCodesignChecker
+    - OCMock
+
 SPEC CHECKSUMS:
   MOLCertificate: c999513316d511c69f290fbf313dfe8dca4ad592
   MOLCodesignChecker: 303c01755646a0045c97f9f0b0fe5945ead42130
@@ -15,4 +21,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: a4ffc6ae7379e3cf6ccaa45702da66fc9527ae30
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.3

--- a/Source/MOLXPCConnection/MOLXPCConnection.h
+++ b/Source/MOLXPCConnection/MOLXPCConnection.h
@@ -114,6 +114,15 @@
 @property(readonly, nonatomic, nullable) id remoteObjectProxy;
 
 /**
+ A synchronous proxy to the object at the other end of the connection. (client)
+
+ @note If the connection to the server failed, this will be nil, so you can safely send messages
+ and rely on the invalidationHandler for handling the failure.
+ @note Methods called on this object will block until the xpc roundtrip is complete.
+ */
+@property(readonly, nonatomic, nullable) id synchronousRemoteObjectProxy;
+
+/**
  The privileged interface this object exports. (server)
  */
 @property(retain, nullable) NSXPCInterface *privilegedInterface;


### PR DESCRIPTION
- Minimize semaphore / dispatch wait in projects that use MOLXPCConnection
- Raises the minimum macOS version to 10.11 - older macOS version can still use MOLXPCConnection v1.2.