### PR TITLE
sync rop

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -22,6 +22,6 @@ objc_library(
 
 macos_unit_test(
     name = "MOLXPCConnectionTests",
-    minimum_os_version = "10.9",
+    minimum_os_version = "10.11",
     deps = [":MOLXPCConnectionTestsLib"],
 )

--- a/MOLXPCConnection.podspec
+++ b/MOLXPCConnection.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'MOLXPCConnection'
-  s.version      = '2.0'
-  s.platform     = :osx, '10.9'
+  s.version      = '2.1'
+  s.platform     = :osx, '10.11'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
   s.homepage     = 'https://github.com/google/macops-molxpcconnection'
   s.authors      = { 'Google Macops' => 'macops-external@google.com' }
@@ -9,5 +9,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/google/macops-molxpcconnection.git',
                      :tag => "v#{s.version}" }
   s.source_files = 'Source/MOLXPCConnection/*.{h,m}'
-  s.dependency 'MOLCodesignChecker', '~> 2.0'
+  s.dependency 'MOLCodesignChecker', '~> 2.2'
 end

--- a/Source/MOLXPCConnection/MOLXPCConnection.h
+++ b/Source/MOLXPCConnection/MOLXPCConnection.h
@@ -114,6 +114,14 @@
 @property(readonly, nonatomic, nullable) id remoteObjectProxy;
 
 /**
+ A synchronous proxy to the object at the other end of the connection. (client)
+
+ @note If the connection to the server failed, this will be nil, so you can safely send messages
+ and rely on the invalidationHandler for handling the failure.
+ */
+@property(readonly, nonatomic, nullable) id synchronousRemoteObjectProxy;
+
+/**
  The privileged interface this object exports. (server)
  */
 @property(retain, nullable) NSXPCInterface *privilegedInterface;

--- a/Source/MOLXPCConnection/MOLXPCConnection.m
+++ b/Source/MOLXPCConnection/MOLXPCConnection.m
@@ -214,6 +214,17 @@
   return nil;
 }
 
+
+- (id)synchronousRemoteObjectProxy {
+  if (self.currentConnection.remoteObjectInterface &&
+      self.currentConnection.remoteObjectInterface != self.validationInterface) {
+    return [self.currentConnection synchronousRemoteObjectProxyWithErrorHandler:^(NSError *error) {
+      [self.currentConnection invalidate];
+    }];
+  }
+  return nil;
+}
+
 #pragma mark Connection tear-down
 
 - (void)invalidate {

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,9 +1,13 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load(
+    "@bazel_tools//tools/build_defs/repo:git.bzl",
+    "git_repository",
+    "new_git_repository",
+)
 
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.6.0",
+    tag = "0.17.2",
 )
 
 load(
@@ -16,19 +20,17 @@ apple_rules_dependencies()
 git_repository(
     name = "MOLCertificate",
     remote = "https://github.com/google/macops-molcertificate.git",
-    tag = "v2.0",
+    tag = "v2.1",
 )
 
 git_repository(
     name = "MOLCodesignChecker",
     remote = "https://github.com/google/macops-molcodesignchecker.git",
-    tag = "v2.0",
+    tag = "v2.2",
 )
 
 new_git_repository(
     name = "OCMock",
-    remote = "https://github.com/erikdoe/ocmock.git",
-    tag = "v3.4.2",
     build_file_content = """
 objc_library(
     name = "OCMock",
@@ -39,4 +41,6 @@ objc_library(
     pch = "Source/OCMock/OCMock-Prefix.pch",
     visibility = ["//visibility:public"],
 )""",
+    remote = "https://github.com/erikdoe/ocmock.git",
+    tag = "v3.4.2",
 )


### PR DESCRIPTION
Docs say 10.11+ for the [synchronousRemoteObjectProxyWithErrorHandler:](https://developer.apple.com/documentation/foundation/nsxpcproxycreating/2879411-synchronousremoteobjectproxywith?language=objc) method. What do you say, time to drop support for 10.9 and 10.10?